### PR TITLE
fix(common): add missing namespace to rawResource template

### DIFF
--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: common
 description: Function library for Helm charts
 type: library
-version: 4.15.2
+version: 4.15.3
 kubeVersion: ">=1.22.0-0"
 keywords:
   - common

--- a/charts/library/common/templates/classes/_rawResource.tpl
+++ b/charts/library/common/templates/classes/_rawResource.tpl
@@ -19,6 +19,7 @@ apiVersion: {{ $resourceObject.apiVersion }}
 kind: {{ $resourceObject.kind }}
 metadata:
   name: {{ $resourceObject.name }}
+  namespace: {{ $rootContext.Release.Namespace }}
   {{- with $labels }}
   labels:
     {{- range $key, $value := . }}


### PR DESCRIPTION
add missing namespace field to rawResource template

#### Added
namespace field to rawResources

#### Changed

### Benefits

### Possible drawbacks

### Applicable issues
- fixes #17 

## Checklist
- [x] Title of the PR conforms to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] Scope of the PR title contains the chart name.
- [x] Chart version in `Chart.yaml` has been bumped according to [Semantic Versioning](https://semver.org/).
- [ ] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [ ] Variables have been documented in the `values.yaml` file.
